### PR TITLE
fix: consistent installer output formatting

### DIFF
--- a/src/installer.cjs
+++ b/src/installer.cjs
@@ -92,6 +92,7 @@ async function run(options = {}) {
     output.success(`Version ${packageVersion} installed`);
 
     // Final message
+    console.log("");
     output.info("Run /donna:setup in Claude Code to get started.");
 }
 

--- a/src/output.cjs
+++ b/src/output.cjs
@@ -23,7 +23,7 @@ function upgradeHeader(from, to) {
 }
 
 function migrationLine(desc) {
-    console.log(`    \u2022 ${desc}`);
+    console.log(`  \u2713 ${desc}`);
 }
 
 module.exports = { banner, success, fail, info, upgradeHeader, migrationLine };


### PR DESCRIPTION
## Summary
- Use `✓` checkmark for migration lines instead of `•` bullet, matching all other success output
- Add blank line before the final "Run /donna:setup" message for visual separation

## Test plan
- [x] All 77 existing tests pass
- [ ] Run `npx @pingvinen/donna-assistant@latest` and verify clean output formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)