### PR TITLE
fix(05): replace timeout binary with Bash tool native timeout parameter

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -96,4 +96,4 @@ Alpha testers using the package. Developed on personal machine, deployed to work
 | Tool-tagged tasks preserve suffix | `[tool](url)` kept on completed tasks for traceability | ✓ Good |
 
 ---
-*Last updated: 2026-03-26 after Phase 04 ingest-github-issues-into-gsd — issue ingestion skill + release-time comments*
+*Last updated: 2026-03-27 after Phase 05 fix-the-constant-timeout-warnings — replaced timeout binary with Bash tool native timeout parameter*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -84,7 +84,7 @@ Plans:
 **Goal:** Remove all `timeout` binary usage from Donna workflows and replace with the Bash tool's native timeout parameter for cross-platform compatibility (ref: #18)
 **Requirements**: TBD
 **Depends on:** Phase 4
-**Plans:** 1 plan
+**Plans:** 1/1 plans complete
 
 Plans:
-- [ ] 05-01-PLAN.md — Remove timeout binary from workflows + update test assertions
+- [x] 05-01-PLAN.md — Remove timeout binary from workflows + update test assertions

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,12 +2,12 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: In progress
-stopped_at: "Completed 05-01-PLAN.md"
-last_updated: "2026-03-27T16:00:00.000Z"
+status: Milestone complete
+stopped_at: Completed 05-01-PLAN.md
+last_updated: "2026-03-27T15:45:14.728Z"
 progress:
   total_phases: 5
-  completed_phases: 4
+  completed_phases: 5
   total_plans: 16
   completed_plans: 16
 ---
@@ -24,7 +24,7 @@ See: .planning/PROJECT.md (updated 2026-03-16)
 ## Current Position
 
 Phase: 05
-Plan: 01 complete
+Plan: Not started
 
 ## Accumulated Context
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: Milestone complete
+status: "Phase 05 shipped — PR #35"
 stopped_at: Completed 05-01-PLAN.md
-last_updated: "2026-03-27T15:45:14.728Z"
+last_updated: "2026-03-27T15:52:38.571Z"
 progress:
   total_phases: 5
   completed_phases: 5

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: Milestone complete
-stopped_at: Phase 5 context gathered
-last_updated: "2026-03-27T15:16:44.773Z"
+status: In progress
+stopped_at: "Completed 05-01-PLAN.md"
+last_updated: "2026-03-27T16:00:00.000Z"
 progress:
   total_phases: 5
   completed_phases: 4
-  total_plans: 15
-  completed_plans: 15
+  total_plans: 16
+  completed_plans: 16
 ---
 
 # Project State
@@ -23,8 +23,8 @@ See: .planning/PROJECT.md (updated 2026-03-16)
 
 ## Current Position
 
-Phase: 04
-Plan: Not started
+Phase: 05
+Plan: 01 complete
 
 ## Accumulated Context
 
@@ -47,6 +47,8 @@ Decisions are logged in PROJECT.md Key Decisions table (17 decisions, all ✓ Go
 - [Phase 04-ingest-github-issues-into-gsd]: ingest-issues skill uses gsd-custom: prefix and inline workflow logic — not installed via Donna installer (D-13, D-14)
 - [Phase 04-ingest-github-issues-into-gsd]: ingested label applied as LAST step per issue for atomicity and safe retry on failure (D-05/pitfall 2)
 - [Phase 04-ingest-github-issues-into-gsd]: Skill stages TODO files with git add but does not commit — developer commits in main context (CLAUDE.md SSH signing constraint)
+- [Phase 05]: Use Bash tool native timeout parameter (ms) instead of external timeout binary — cross-platform, no coreutils required on macOS
+- [Phase 05]: Same timeout durations preserved: 10s (10000ms) for tool commands, 15s (15000ms) for GraphQL introspection
 
 ### Pending Todos
 
@@ -84,6 +86,5 @@ Decisions are logged in PROJECT.md Key Decisions table (17 decisions, all ✓ Go
 
 ## Session Continuity
 
-Last session: 2026-03-27T15:16:44.771Z
-Stopped at: Phase 5 context gathered
-Resume file: .planning/phases/05-fix-the-constant-timeout-warnings/05-CONTEXT.md
+Last session: 2026-03-27T16:00:00.000Z
+Stopped at: Completed 05-01-PLAN.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -19,7 +19,7 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-16)
 
 **Core value:** Never forget an important task again -- the assistant knows your role, surfaces what needs attention each day, and captures everything that falls through the cracks outside your ticketing system.
-**Current focus:** Phase 03 — prioritized-now-view-distill-daily-file-to-focus-items
+**Current focus:** Phase 05 — fix-the-constant-timeout-warnings
 
 ## Current Position
 

--- a/.planning/phases/05-fix-the-constant-timeout-warnings/05-01-SUMMARY.md
+++ b/.planning/phases/05-fix-the-constant-timeout-warnings/05-01-SUMMARY.md
@@ -1,0 +1,94 @@
+---
+phase: 05-fix-the-constant-timeout-warnings
+plan: 01
+subsystem: workflows
+tags: [timeout, cross-platform, macOS, bash-tool]
+dependency_graph:
+  requires: []
+  provides: [timeout-free-workflows, updated-test-assertions]
+  affects: [workflows/begin-the-day.md, workflows/run-tools.md, workflows/focus.md, workflows/add-tool.md, workflows/relearn-tools.md, test/stubs.test.cjs]
+tech_stack:
+  added: []
+  patterns: [Bash tool native timeout parameter instead of external timeout binary]
+key_files:
+  created: []
+  modified:
+    - workflows/begin-the-day.md
+    - workflows/run-tools.md
+    - workflows/focus.md
+    - workflows/add-tool.md
+    - workflows/relearn-tools.md
+    - test/stubs.test.cjs
+decisions:
+  - "Use Bash tool native timeout parameter (ms) instead of external timeout binary — cross-platform, no coreutils required"
+  - "Preserve same timeout durations: 10s (10000ms) for tool commands, 15s (15000ms) for GraphQL introspection"
+  - "Keep error message templates (timed out after 10s) and failure condition prose unchanged"
+metrics:
+  duration_seconds: 152
+  completed_date: "2026-03-27"
+  tasks_completed: 2
+  tasks_total: 2
+  files_modified: 6
+---
+
+# Phase 05 Plan 01: Remove timeout Binary from Workflows Summary
+
+**One-liner:** Replaced all `timeout N cmd` binary invocations across 5 workflow files with Bash tool native `timeout` parameter prose (10000ms/15000ms), eliminating macOS coreutils dependency and constant warnings.
+
+## Tasks Completed
+
+| # | Task | Commit | Files |
+|---|------|--------|-------|
+| 1 | Remove timeout binary from all 5 workflow files | 2c778fd | workflows/begin-the-day.md, run-tools.md, focus.md, add-tool.md, relearn-tools.md |
+| 2 | Update test assertions and verify full suite passes | 15efa3d | test/stubs.test.cjs |
+
+## What Was Built
+
+### Task 1: Workflow file updates
+
+Replaced all 15+ `timeout N <command>` binary invocations across 5 workflow files with prose instructing Claude to use the Bash tool's native `timeout` parameter:
+
+- **CLI/REST/GraphQL commands (10s):** "Run via Bash (set the Bash tool's `timeout` parameter to `10000`):"
+- **GraphQL introspection (15s):** "Run via Bash with a 15-second timeout (set the Bash tool's `timeout` parameter to `15000`)."
+- **add-tool auth tests:** Inline format — "run `<cmd>` via Bash with `timeout: 10000`"
+- **run-tools smart-merge gh check:** Updated inline prose to use "set the Bash tool's `timeout` parameter to `10000`"
+
+Error message templates like "timed out after 10s" and failure condition prose ("non-zero exit, timeout, missing secret") were preserved unchanged.
+
+### Task 2: Test assertion updates
+
+Updated 2 assertions in `test/stubs.test.cjs`:
+
+1. `workflow: workflows/run-tools.md` — "contains timeout for failure isolation" changed to "contains Bash tool timeout parameter for failure isolation", checking `content.includes("10000")` instead of `content.includes("timeout")`
+2. `cross-cutting: begin-the-day tool integration` — "includes timeout for failure isolation" changed to "includes Bash tool timeout parameter for failure isolation", checking `content.includes("10000")` instead of the old OR condition
+
+Full test suite: 287 tests, 0 failures.
+
+## Verification Results
+
+- `grep -rn "timeout [0-9]" workflows/*.md` → 0 matches
+- `grep -c "10000" workflows/begin-the-day.md` → 3
+- `grep -c "10000" workflows/run-tools.md` → 4
+- `grep -c "10000" workflows/focus.md` → 3
+- `grep -c "10000" workflows/add-tool.md` → 4
+- `grep -c "15000" workflows/relearn-tools.md` → 1
+- `grep -c "timed out after 10s" workflows/begin-the-day.md` → 1 (preserved)
+- `npm test` → 287 passed, 0 failed
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None. All timeout parameter values are correct and complete — no placeholder values remain.
+
+## Self-Check: PASSED
+
+- workflows/begin-the-day.md: exists, contains "10000" (3 occurrences)
+- workflows/run-tools.md: exists, contains "10000" (4 occurrences)
+- workflows/focus.md: exists, contains "10000" (3 occurrences)
+- workflows/add-tool.md: exists, contains "10000" (4 occurrences)
+- workflows/relearn-tools.md: exists, contains "15000" (1 occurrence)
+- test/stubs.test.cjs: exists, contains "10000" (4 occurrences), zero "timeout 10"
+- Commits 2c778fd and 15efa3d verified in git log

--- a/.planning/phases/05-fix-the-constant-timeout-warnings/05-VERIFICATION.md
+++ b/.planning/phases/05-fix-the-constant-timeout-warnings/05-VERIFICATION.md
@@ -1,0 +1,91 @@
+---
+phase: 05-fix-the-constant-timeout-warnings
+verified: 2026-03-27T00:00:00Z
+status: passed
+score: 4/4 must-haves verified
+---
+
+# Phase 05: Fix the Constant Timeout Warnings Verification Report
+
+**Phase Goal:** Remove all `timeout` binary usage from Donna workflows and replace with the Bash tool's native timeout parameter for cross-platform compatibility
+**Verified:** 2026-03-27
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | No workflow file contains the string `timeout N` as a bash command prefix | VERIFIED | `grep -n "timeout [0-9]" workflows/*.md` returns 0 matches across all 5 files |
+| 2 | All workflows still instruct Claude to use a timeout when running tool commands | VERIFIED | All 5 workflow files contain Bash tool timeout parameter prose (10000 or 15000) |
+| 3 | Timeout durations are preserved (10s for tool commands, 15s for GraphQL introspection) | VERIFIED | `begin-the-day.md` (3x 10000), `run-tools.md` (4x 10000), `focus.md` (3x 10000), `add-tool.md` (4x 10000), `relearn-tools.md` (1x 15000) |
+| 4 | All existing tests pass after the changes | VERIFIED | `npm test` → 287 passed, 0 failed |
+
+**Score:** 4/4 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `workflows/begin-the-day.md` | Tool execution instructions without timeout binary, contains "10000" | VERIFIED | Exists, contains 3 occurrences of "10000" in Bash tool prose |
+| `workflows/run-tools.md` | Tool execution instructions without timeout binary, contains "10000" | VERIFIED | Exists, contains 4 occurrences of "10000" in Bash tool prose |
+| `workflows/focus.md` | Tool execution instructions without timeout binary, contains "10000" | VERIFIED | Exists, contains 3 occurrences of "10000" in Bash tool prose |
+| `workflows/add-tool.md` | Auth test instructions without timeout binary, contains "10000" | VERIFIED | Exists, contains 4 occurrences of "10000" in Bash tool prose |
+| `workflows/relearn-tools.md` | GraphQL introspection instructions without timeout binary, contains "15000" | VERIFIED | Exists, contains 1 occurrence of "15000" in Bash tool prose |
+| `test/stubs.test.cjs` | Updated assertions checking for Bash tool timeout parameter, contains "10000" | VERIFIED | Exists, contains 4 occurrences of "10000"; zero occurrences of old "timeout 10" pattern |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `test/stubs.test.cjs` | `workflows/run-tools.md` | `content.includes("10000")` assertion | WIRED | Line 825: `content.includes("10000")` assertion verified |
+| `test/stubs.test.cjs` | `workflows/begin-the-day.md` | `content.includes("10000")` assertion | WIRED | Line 897: `content.includes("10000")` assertion verified |
+
+### Data-Flow Trace (Level 4)
+
+Not applicable — this phase modifies markdown workflow documents and test assertions, not components rendering dynamic data.
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| No timeout binary invocations remain | `grep -n "timeout [0-9]" workflows/*.md \| wc -l` | 0 | PASS |
+| begin-the-day.md has 3x 10000 | `grep -c "10000" workflows/begin-the-day.md` | 3 | PASS |
+| run-tools.md has 4x 10000 | `grep -c "10000" workflows/run-tools.md` | 4 | PASS |
+| focus.md has 3x 10000 | `grep -c "10000" workflows/focus.md` | 3 | PASS |
+| add-tool.md has 4x 10000 | `grep -c "10000" workflows/add-tool.md` | 4 | PASS |
+| relearn-tools.md has 1x 15000 | `grep -c "15000" workflows/relearn-tools.md` | 1 | PASS |
+| Error message template preserved | `grep -c "timed out after 10s" workflows/begin-the-day.md` | 1 | PASS |
+| Full test suite passes | `npm test` | 287 passed, 0 failed | PASS |
+| Test assertions use new pattern | `grep -c "10000" test/stubs.test.cjs` | 4 | PASS |
+| Old timeout binary assertions removed | `grep -c "timeout 10" test/stubs.test.cjs` | 0 | PASS |
+
+### Requirements Coverage
+
+No formal requirement IDs were mapped to this phase (`requirements: []` in PLAN frontmatter, "TBD" in ROADMAP.md). No REQUIREMENTS.md cross-reference needed.
+
+### Anti-Patterns Found
+
+No anti-patterns detected. Scanned all 6 modified files for TODOs, placeholders, and stub patterns — none found.
+
+### Human Verification Required
+
+None. All verification was completed programmatically.
+
+### Gaps Summary
+
+No gaps. All must-haves verified against the actual codebase:
+
+- All 15+ `timeout N` binary invocations removed from 5 workflow files
+- Replacement prose correctly instructs use of Bash tool native timeout parameter with correct millisecond values
+- Error message templates and failure condition prose unchanged (verified "timed out after 10s" preserved)
+- Both test assertions updated to check for "10000" pattern; old "timeout 10" pattern absent
+- Phase commits 2c778fd and 15efa3d confirmed in git log
+- Full test suite (287 tests) passes with zero failures
+
+---
+
+_Verified: 2026-03-27_
+_Verifier: Claude (gsd-verifier)_

--- a/test/stubs.test.cjs
+++ b/test/stubs.test.cjs
@@ -819,11 +819,11 @@ describe("workflow: workflows/run-tools.md", () => {
         assert.ok(content.includes("## Resolved"), "Should reference ## Resolved section format");
     });
 
-    it("contains timeout for failure isolation", () => {
+    it("contains Bash tool timeout parameter for failure isolation", () => {
         const content = fs.readFileSync(runToolsWorkflowPath, "utf8");
         assert.ok(
-            content.includes("timeout"),
-            "Should contain timeout for per-tool failure isolation",
+            content.includes("10000"),
+            "Should use Bash tool timeout parameter (10000ms) for per-tool failure isolation",
         );
     });
 
@@ -891,11 +891,11 @@ describe("cross-cutting: begin-the-day tool integration", () => {
         );
     });
 
-    it("includes timeout for failure isolation", () => {
+    it("includes Bash tool timeout parameter for failure isolation", () => {
         const content = fs.readFileSync(beginTheDayWorkflowPath, "utf8");
         assert.ok(
-            content.includes("timeout 10") || content.includes("timeout"),
-            "begin-the-day should use timeout for tool command failure isolation",
+            content.includes("10000"),
+            "begin-the-day should use Bash tool timeout parameter (10000ms) for tool command failure isolation",
         );
     });
 

--- a/workflows/add-tool.md
+++ b/workflows/add-tool.md
@@ -163,11 +163,11 @@ Store the output as `<version>`. If the command does not support `--version`, st
 <step name="auth-test">
 **If `<tool_type>` is `cli`:**
 
-For well-known tools, run the appropriate auth test via Bash with a 10-second timeout:
+For well-known tools, run the appropriate auth test via Bash (set the Bash tool's `timeout` parameter to `10000`):
 
-- `gh`: `timeout 10 gh api user --jq '.login' 2>&1`
-- `jira`: `timeout 10 jira me 2>&1`
-- `kubectl`: `timeout 10 kubectl auth whoami 2>&1`
+- `gh`: run `gh api user --jq '.login' 2>&1` via Bash with `timeout: 10000`
+- `jira`: run `jira me 2>&1` via Bash with `timeout: 10000`
+- `kubectl`: run `kubectl auth whoami 2>&1` via Bash with `timeout: 10000`
 - Other tools: skip auth test, print `ℹ No known auth test for <command>. Verify manually.`
 
 On success (exit 0): print `✓ Authenticated as <output>`.

--- a/workflows/begin-the-day.md
+++ b/workflows/begin-the-day.md
@@ -178,9 +178,9 @@ Store the parsed tools and their capabilities as `<registered_tools>`.
 
 For `type: cli` capabilities (format: `<name>: <cli_invocation>`):
 
-Run via Bash with a 10-second timeout:
+Run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 <cli_invocation> 2>&1
+<cli_invocation> 2>&1
 ```
 
 **On success (exit 0):**
@@ -210,9 +210,9 @@ Add the warning to `<tool_warnings>`. Continue to next capability/tool. Never re
 For `type: rest` capabilities (format: `<name>: <METHOD> /path`):
 1. Read `<storage_repo>/donna/secrets.md` with the Read tool. Parse key-value pairs from under the frontmatter.
 2. Resolve the `auth_secret` key to get the actual secret value. If the key is not found in secrets.md or the value is `REPLACE_WITH_YOUR_SECRET`, add warning `! <tool_name>: missing secret <auth_secret> — edit donna/secrets.md` and skip this tool.
-3. For each capability, run via Bash with a 10-second timeout:
+3. For each capability, run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 curl -s -H "<auth_header>: <resolved_secret>" "<base_url><path>" 2>&1
+curl -s -H "<auth_header>: <resolved_secret>" "<base_url><path>" 2>&1
 ```
 4. Parse the JSON response using Claude's understanding to extract task-like items. Format:
 `- [ ] (<tool_name>) <description> [<identifier>](<url>)`
@@ -223,9 +223,9 @@ Continue. Never retry.
 
 For `type: graphql` capabilities (format: `<name>: <graphql_query>`):
 1. Same secrets resolution as REST.
-2. For each capability, run via Bash with a 10-second timeout:
+2. For each capability, run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 curl -s -X POST -H "<auth_header>: <resolved_secret>" -H "Content-Type: application/json" -d '{"query":"<graphql_query>"}' "<base_url>" 2>&1
+curl -s -X POST -H "<auth_header>: <resolved_secret>" -H "Content-Type: application/json" -d '{"query":"<graphql_query>"}' "<base_url>" 2>&1
 ```
 3. Parse the JSON response to extract task-like items. Same format as REST.
 

--- a/workflows/focus.md
+++ b/workflows/focus.md
@@ -154,23 +154,25 @@ For each matched tool, extract:
 **Type-aware execution within each agent (or direct execution for single tool):**
 
 For `type: cli` capabilities (format: `<name>: <cli_invocation>`):
+
+Run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 <cli_invocation> 2>&1
+<cli_invocation> 2>&1
 ```
 
 For `type: rest` capabilities (format: `<name>: <METHOD> /path`):
 1. Read `<storage_repo>/donna/secrets.md` with the Read tool. Parse key-value pairs from under the frontmatter.
 2. Resolve the `auth_secret` key to get the actual secret value. If the key is not found in secrets.md or the value is `REPLACE_WITH_YOUR_SECRET`, add warning `! <tool_name>: missing secret <auth_secret> — edit donna/secrets.md` and skip this tool.
-3. For each capability, run via Bash with a 10-second timeout:
+3. For each capability, run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 curl -s -H "<auth_header>: <resolved_secret>" "<base_url><path>" 2>&1
+curl -s -H "<auth_header>: <resolved_secret>" "<base_url><path>" 2>&1
 ```
 
 For `type: graphql` capabilities (format: `<name>: <graphql_query>`):
 1. Same secrets resolution as REST.
-2. For each capability, run via Bash with a 10-second timeout:
+2. For each capability, run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 curl -s -X POST -H "<auth_header>: <resolved_secret>" -H "Content-Type: application/json" -d '{"query":"<graphql_query>"}' "<base_url>" 2>&1
+curl -s -X POST -H "<auth_header>: <resolved_secret>" -H "Content-Type: application/json" -d '{"query":"<graphql_query>"}' "<base_url>" 2>&1
 ```
 
 For `type: mcp` capabilities (format: `<name>: mcp:<server>/<tool>`):

--- a/workflows/relearn-tools.md
+++ b/workflows/relearn-tools.md
@@ -116,10 +116,10 @@ If `<type>` is `graphql`:
 
   1. Attempt to read `<storage_repo>/donna/secrets.md` with the Read tool. If the file exists and contains the `auth_secret` key with a value that is not a placeholder (does not contain "REPLACE_WITH"), set `<resolved_secret>` to that value. Otherwise, set `<resolved_secret>` to empty (no auth). **An empty resolved_secret is perfectly valid — proceed to step 2 regardless.**
 
-  2. Run via Bash with a 15-second timeout. Include the auth header only when a real secret was resolved:
+  2. Run via Bash with a 15-second timeout (set the Bash tool's `timeout` parameter to `15000`). Include the auth header only when a real secret was resolved:
      - If `<resolved_secret>` is non-empty:
        ```bash
-       timeout 15 curl -s -X POST \
+       curl -s -X POST \
          -H "<auth_header>: <resolved_secret>" \
          -H "Content-Type: application/json" \
          -d '{"query":"{ __schema { types { name fields { name type { name } } } } }"}' \
@@ -127,7 +127,7 @@ If `<type>` is `graphql`:
        ```
      - If `<resolved_secret>` is empty (public API or no secret configured):
        ```bash
-       timeout 15 curl -s -X POST \
+       curl -s -X POST \
          -H "Content-Type: application/json" \
          -d '{"query":"{ __schema { types { name fields { name type { name } } } } }"}' \
          "<base_url>" 2>&1

--- a/workflows/run-tools.md
+++ b/workflows/run-tools.md
@@ -143,9 +143,9 @@ If the `## From Tools` section does not exist in today's file, set `<existing_to
 
 For `type: cli` capabilities (format: `<name>: <cli_invocation>`):
 
-Run the capability command via Bash with a 10-second timeout:
+Run the capability command via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 <capability_command> 2>&1
+<capability_command> 2>&1
 ```
 
 **On success (exit 0):** Parse the output into task entries. Every task line MUST include both a tool tag and a descriptive link.
@@ -176,9 +176,9 @@ Continue to the next capability. Never retry.
 For `type: rest` capabilities (format: `<name>: <METHOD> /path`):
 1. Read `<storage_repo>/donna/secrets.md` with the Read tool. Parse key-value pairs from under the frontmatter.
 2. Resolve the `auth_secret` key to get the actual secret value. If the key is not found in secrets.md or the value is `REPLACE_WITH_YOUR_SECRET`, add warning `! <tool_name>: missing secret <auth_secret> — edit donna/secrets.md` and skip this tool.
-3. For each capability, run via Bash with a 10-second timeout:
+3. For each capability, run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 curl -s -H "<auth_header>: <resolved_secret>" "<base_url><path>" 2>&1
+curl -s -H "<auth_header>: <resolved_secret>" "<base_url><path>" 2>&1
 ```
 4. Parse the JSON response using Claude's understanding to extract task-like items. Format:
 `- [ ] (<tool_name>) <description> [<identifier>](<url>)`
@@ -189,9 +189,9 @@ Continue. Never retry.
 
 For `type: graphql` capabilities (format: `<name>: <graphql_query>`):
 1. Same secrets resolution as REST.
-2. For each capability, run via Bash with a 10-second timeout:
+2. For each capability, run via Bash (set the Bash tool's `timeout` parameter to `10000`):
 ```bash
-timeout 10 curl -s -X POST -H "<auth_header>: <resolved_secret>" -H "Content-Type: application/json" -d '{"query":"<graphql_query>"}' "<base_url>" 2>&1
+curl -s -X POST -H "<auth_header>: <resolved_secret>" -H "Content-Type: application/json" -d '{"query":"<graphql_query>"}' "<base_url>" 2>&1
 ```
 3. Parse the JSON response to extract task-like items. Same format as REST.
 
@@ -223,7 +223,7 @@ For each URL in `<existing_tool_lines>`:
 1. If the line is `[x]` (user manually checked): **KEEP AS-IS** — user intent wins (Rule 1). Do not change regardless of tool state.
 2. If the line is `[ ]` AND the URL exists in `<fresh_tool_tasks>`: **KEEP OPEN** — item is still active (Rule 2).
 3. If the line is `[ ]` AND the URL is NOT in `<fresh_tool_tasks>`: the item was removed from the tool (reassigned, deleted, or closed).
-   - For gh items: check if the PR/issue was closed or merged via Bash: `timeout 10 gh pr view <number> --json state --jq '.state' 2>/dev/null || timeout 10 gh issue view <number> --json state --jq '.state' 2>/dev/null`
+   - For gh items: check if the PR/issue was closed or merged via Bash (set the Bash tool's `timeout` parameter to `10000`): `gh pr view <number> --json state --jq '.state' 2>/dev/null || gh issue view <number> --json state --jq '.state' 2>/dev/null`
    - If closed or merged: change to `- [x] (<tool>) <description> [<identifier>](<url>) (<reason>)` and move to `## Resolved` (Rule 3a).
    - If status check fails or item simply no longer appears: move to `## Resolved` with `(removed)` (Rule 3b).
 


### PR DESCRIPTION
## Summary

**Phase 05: fix-the-constant-timeout-warnings**
**Goal:** Remove all `timeout N` binary invocations from Donna workflow files and replace them with the Bash tool's native `timeout` parameter
**Status:** Verified ✓ (4/4 must-haves)

The `timeout` binary isn't available on macOS without coreutils, causing constant "command not found" warnings when Donna runs. All 5 workflow files now instruct Claude to use the Bash tool's built-in `timeout` parameter (in milliseconds) instead — cross-platform, zero external dependencies.

## Changes

### Plan 05-01: Remove timeout binary from workflows
Replaced all `timeout N cmd` binary invocations across 5 workflow files with Bash tool native `timeout` parameter prose (10000ms/15000ms).

**Key files modified:**
- `workflows/begin-the-day.md` — 3 occurrences (CLI, REST, GraphQL)
- `workflows/run-tools.md` — 4 occurrences (CLI, REST, GraphQL, smart-merge gh check)
- `workflows/focus.md` — 3 occurrences
- `workflows/add-tool.md` — 4 auth test references
- `workflows/relearn-tools.md` — 2 GraphQL introspection blocks (15000ms)
- `test/stubs.test.cjs` — 2 assertions updated to check for `10000` instead of `timeout`

## Verification

- [x] Automated verification: passed (4/4 must-haves)
- [x] Zero `timeout [0-9]` patterns remain in any workflow file
- [x] All 287 tests pass
- [x] Error message templates ("timed out after 10s") preserved unchanged

## Key Decisions

- Use Bash tool native `timeout` parameter (ms) instead of external timeout binary — cross-platform, no coreutils required
- Preserve same timeout durations: 10s → 10000ms for tool commands, 15s → 15000ms for GraphQL introspection
- Keep error message templates and failure condition prose unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)